### PR TITLE
Add option to fail check on violations

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Optional. Title for the check run to create. Defaults to `PMD Source Code Analyz
 ### `token`
 Optional. GitHub API access token. Defaults to `${{ github.token }}`, which is set by `actions/checkout@v2` minimally.
 
+### `fail-on-violation`
+Optional. Whether to fail the check if any violations are found. Defaults to `false`.
+
 ## Example usage
 
 ```yaml

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,5 +2,6 @@ export enum Inputs {
   Name = 'name',
   Title = 'title',
   Path = 'path',
-  Token = 'token'
+  Token = 'token',
+  FailOnViolation = 'fail-on-violation'
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ async function run(): Promise<void> {
     const path = core.getInput(Inputs.Path, {required: true})
     const name = core.getInput(Inputs.Name)
     const title = core.getInput(Inputs.Title)
+    const failOnViolations = core.getBooleanInput(Inputs.FailOnViolation)
 
     const searchResult = await findResults(path)
     if (searchResult.filesToUpload.length === 0) {
@@ -41,7 +42,7 @@ async function run(): Promise<void> {
       core.debug(`Created ${groupedAnnotations.length} buckets`)
 
       for (const annotationSet of groupedAnnotations) {
-        await createCheck(name, title, annotationSet, annotations.length)
+        await createCheck(name, title, annotationSet, annotations.length, failOnViolations)
       }
     }
   } catch (error) {
@@ -53,7 +54,8 @@ async function createCheck(
   name: string,
   title: string,
   annotations: Annotation[],
-  numErrors: number
+  numErrors: number,
+  failOnViolations: boolean
 ): Promise<void> {
   const octokit = getOctokit(core.getInput(Inputs.Token))
   let sha = context.sha
@@ -78,7 +80,7 @@ async function createCheck(
       head_sha: sha,
       name,
       status: 'completed' as const,
-      conclusion: numErrors === 0 ? ('success' as const) : ('neutral' as const),
+      conclusion: numErrors === 0 ? ('success' as const) : failOnViolations ? ('failure' as const) : ('neutral' as const),
       output: {
         title,
         summary: `${numErrors} violation(s) found`,
@@ -94,7 +96,7 @@ async function createCheck(
       ...context.repo,
       check_run_id,
       status: 'completed' as const,
-      conclusion: numErrors === 0 ? ('success' as const) : ('neutral' as const),
+      conclusion: numErrors === 0 ? ('success' as const) : failOnViolations ? ('failure' as const) : ('neutral' as const),
       output: {
         title,
         summary: `${numErrors} violation(s) found`,


### PR DESCRIPTION
Implements the idea of setting the status to failure on violations. Original seen in https://github.com/jwgmeligmeyling/pmd-github-action/issues/146.

It's implemented as an option called _fail-on-violation_ and it defaults to false to keep the current behavior if not specified.